### PR TITLE
feat: introduce GitLab Releases provider

### DIFF
--- a/src/gitlab_release_provider.rs
+++ b/src/gitlab_release_provider.rs
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under both the MIT license found in the
+ * LICENSE-MIT file in the root directory of this source tree and the Apache
+ * License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+ * of this source tree.
+ */
+
+use std::path::Path;
+use std::process::Command;
+
+use serde::Deserialize;
+use serde_jsonrc::value::Value;
+
+use crate::config::ArtifactEntry;
+use crate::provider::Provider;
+use crate::util::file_lock::FileLock;
+
+pub struct GitLabReleaseProvider {}
+
+#[derive(Deserialize, Debug, PartialEq)]
+struct GitLabReleaseProviderConfig {
+    tag: String,
+    repo: String,
+    name: String,
+}
+
+impl Provider for GitLabReleaseProvider {
+    fn fetch_artifact(
+        &self,
+        provider_config: &Value,
+        destination: &Path,
+        _fetch_lock: &FileLock,
+        _artifact_entry: &ArtifactEntry,
+    ) -> anyhow::Result<()> {
+        let GitLabReleaseProviderConfig { tag, repo, name } =
+            GitLabReleaseProviderConfig::deserialize(provider_config)?;
+
+        let _output = Command::new("glab")
+            .arg("release")
+            .arg("download")
+            .arg(tag)
+            .arg("--repo")
+            .arg(repo)
+            .arg("--asset-name")
+            .arg(name)
+            .arg("--dir")
+            .arg(destination)
+            .output()?;
+
+        Ok(())
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ mod download;
 mod execution;
 mod fetch_method;
 mod github_release_provider;
+mod gitlab_release_provider;
 mod http_provider;
 mod platform;
 mod print_entry_for_url;
@@ -30,6 +31,7 @@ use std::env;
 use std::process::ExitCode;
 
 use anyhow::format_err;
+use gitlab_release_provider::GitLabReleaseProvider;
 
 use crate::github_release_provider::GitHubReleaseProvider;
 use crate::http_provider::HttpProvider;
@@ -49,6 +51,7 @@ impl ProviderFactory for DefaultProviderFactory {
         match provider_type {
             "http" => Ok(Box::new(HttpProvider {})),
             "github-release" => Ok(Box::new(GitHubReleaseProvider {})),
+            "gitlab-release" => Ok(Box::new(GitLabReleaseProvider {})),
             _ => Err(format_err!("unknown provider type: `{}`", provider_type)),
         }
     }


### PR DESCRIPTION
__NOTE: This is still a draft. I haven't yet tested it out against a GitLab Release to ensure it does the right thing. This is _just_ the initial code modeled after the GitHub Releases provider implementation.__

This commit implements a GitLab Releases provider, modeled after the GitHub Releases provider. It uses the `glab` command line interface (CLI) to handle downloads, and delegates to that CLI for error handling.

I did experiment briefly with using the Rust `glob` crate to eagerly identify errors in glob patterns passed for matching artifacts, but that crate didn't exactly match the Go `path/filepath.Match` [1] logic and I didn't want to introduce any weird incompatibilities between the two layers.

[1]: https://pkg.go.dev/path/filepath#Match