### PR TITLE
Support .tar.xz archives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,6 +235,7 @@ dependencies = [
  "tar",
  "tempfile",
  "thiserror",
+ "xz2",
  "zstd",
 ]
 
@@ -339,6 +340,17 @@ name = "linux-raw-sys"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
+
+[[package]]
+name = "lzma-sys"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
 
 [[package]]
 name = "memoffset"
@@ -786,6 +798,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4686009f71ff3e5c4dbcf1a282d0a44db3f021ba69350cd42086b3e5f1c6985"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "xz2"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+dependencies = [
+ "lzma-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ sha2 = "0.10.6"
 tar = "0.4.40"
 tempfile = "3.8"
 thiserror = "1.0.49"
+xz2 = { version = "0.1.7", features = ["static"] }
 zstd = { version = "0.13", features = ["experimental", "zstdmt"] }
 
 [dev-dependencies]

--- a/src/artifact_location.rs
+++ b/src/artifact_location.rs
@@ -104,6 +104,7 @@ fn create_key_for_format(entry: &ArtifactEntry) -> Cow<'_, str> {
             match decompress {
                 None => Cow::Borrowed("tar"),
                 Some(DecompressStep::Gzip) => Cow::Borrowed("tar.gz"),
+                Some(DecompressStep::Xz) => Cow::Borrowed("tar.xz"),
                 Some(DecompressStep::Zstd) => Cow::Borrowed("tar.zst"),
             }
         }
@@ -115,6 +116,7 @@ fn create_key_for_format(entry: &ArtifactEntry) -> Cow<'_, str> {
             match decompress {
                 None => Cow::Owned(format!("file:{}", path)),
                 Some(DecompressStep::Gzip) => Cow::Owned(format!("file.gz:{}", path)),
+                Some(DecompressStep::Xz) => Cow::Owned(format!("file.xz:{}", path)),
                 Some(DecompressStep::Zstd) => Cow::Owned(format!("file.zst:{}", path)),
             }
         }

--- a/src/fetch_method.rs
+++ b/src/fetch_method.rs
@@ -29,12 +29,16 @@ pub enum ArtifactFormat {
     #[serde(rename = "tar.zst")]
     TarZstd,
 
+    #[serde(rename = "tar.xz")]
+    TarXz,
+
     #[serde(rename = "zst")]
     Zstd,
 }
 
 pub enum DecompressStep {
     Gzip,
+    Xz,
     Zstd,
 }
 
@@ -50,6 +54,7 @@ impl ArtifactFormat {
             Self::Gz => (Some(DecompressStep::Gzip), None),
             Self::Tar => (None, Some(ArchiveFormat::Tar)),
             Self::TarGz => (Some(DecompressStep::Gzip), Some(ArchiveFormat::Tar)),
+            Self::TarXz => (Some(DecompressStep::Xz), Some(ArchiveFormat::Tar)),
             Self::TarZstd => (Some(DecompressStep::Zstd), Some(ArchiveFormat::Tar)),
             Self::Zstd => (Some(DecompressStep::Zstd), None),
         }

--- a/src/print_entry_for_url.rs
+++ b/src/print_entry_for_url.rs
@@ -84,6 +84,8 @@ fn guess_artifact_format_from_url(url: &[u8]) -> ArtifactFormat {
         ArtifactFormat::TarGz
     } else if url.ends_with(b".tar.zst") || url.ends_with(b".tzst") {
         ArtifactFormat::TarZstd
+    } else if url.ends_with(b".tar.xz") {
+        ArtifactFormat::TarXz
     } else if url.ends_with(b".tar") {
         ArtifactFormat::Tar
     } else if url.ends_with(b".gz") {
@@ -168,6 +170,7 @@ mod tests {
 
         test("http://example.com/foo.tar.gz", ArtifactFormat::TarGz);
         test("http://example.com/foo.tgz", ArtifactFormat::TarGz);
+        test("http://example.com/foo.tar.xz", ArtifactFormat::TarXz);
         test("http://example.com/foo.tar.zst", ArtifactFormat::TarZstd);
         test("http://example.com/foo.tzst", ArtifactFormat::TarZstd);
         test("http://example.com/foo.tar", ArtifactFormat::Tar);

--- a/website/docs/dotslash-file.md
+++ b/website/docs/dotslash-file.md
@@ -324,9 +324,11 @@ properties:
 | `format`  | Archive? | Decompress? |
 | --------- | -------- | ----------- |
 | `tar.gz`  | yes      | gzip        |
+| `tar.xz`  | yes      | xz          |
 | `tar.zst` | yes      | zstd        |
 | `tar`     | yes      | _none_      |
 | `gz`      | no       | gzip        |
+| `xz`      | no       | xz          |
 | `zst`     | no       | zstd        |
 | _omitted_ | no       | _none_      |
 


### PR DESCRIPTION
Some projecst are only available as .tar.xz archives.
For example, [Zig releases](https://ziglang.org/download/)
for Linux and macOS are only available as .tar.xz archives.

This PR adds support to dotslash for .tar.xz archives,
using the xz2 crate to provide the functionality.
The xz2 create wraps the liblzma library.

In this change, the library is linked statically,
so that the resulting binary does not depend on the
liblzma library being installed on the system.

**File size impact**:

```
❯ uname -s
Darwin

❯ git checkout main
❯ cargo build --release
❯ wc -c target/release/dotslash
  985208 target/release/dotslash

❯ git checkout tarxz
❯ cargo build --release
❯ wc -c target/release/dotslash
 1052776 target/release/dotslash
```

This increases the binary size by 67,568 bytes on macOS.
It comes down to 16,704 if we use dynamic linking.
For now, I've chosen to use static linking.

**Licensing concerns**:

Per [xz/COPYING](https://github.com/xz-mirror/xz/blob/2327a461e1afce862c22269b80d3517801103c1b/COPYING),

> liblzma is in the public domain.

So it should be safe to link statically or dynamically
from a licensing point of view.

**Testing**:
We'll need to update https://github.com/zertosh/dotslash_fixtures to
generate a .tar.xz archive as well to be able to add a fixture for it.

Resolves #10
