### PR TITLE
Support .zip archives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,6 +122,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "cc"
 version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -172,6 +178,12 @@ checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if 1.0.0",
 ]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
 name = "crypto-common"
@@ -236,7 +248,8 @@ dependencies = [
  "tempfile",
  "thiserror",
  "xz2",
- "zstd",
+ "zip",
+ "zstd 0.13.0",
 ]
 
 [[package]]
@@ -810,12 +823,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+dependencies = [
+ "byteorder",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
+ "zstd 0.11.2+zstd.1.5.2",
+]
+
+[[package]]
+name = "zstd"
+version = "0.11.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+dependencies = [
+ "zstd-safe 5.0.2+zstd.1.5.2",
+]
+
+[[package]]
 name = "zstd"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bffb3309596d527cfcba7dfc6ed6052f1d39dfbd7c867aa2e865e4a449c10110"
 dependencies = [
- "zstd-safe",
+ "zstd-safe 7.0.0",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "5.0.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+dependencies = [
+ "libc",
+ "zstd-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ tempfile = "3.8"
 thiserror = "1.0.49"
 xz2 = { version = "0.1.7", features = ["static"] }
 zstd = { version = "0.13", features = ["experimental", "zstdmt"] }
+zip = { version = "0.6.6", default-features = false, features = ["deflate", "zstd"] }
 
 [dev-dependencies]
 assert_matches = "1.5"

--- a/src/artifact_location.rs
+++ b/src/artifact_location.rs
@@ -108,6 +108,14 @@ fn create_key_for_format(entry: &ArtifactEntry) -> Cow<'_, str> {
                 Some(DecompressStep::Zstd) => Cow::Borrowed("tar.zst"),
             }
         }
+        (decompress, Some(ArchiveFormat::Zip)) => {
+            if let Some(d) = decompress {
+                // extraction_policy never returns (Some(_), Some(ArchiveFormat::Zip)).
+                // If we get here, panic because it's a bug.
+                panic!("zip files cannot be compressed with {:?}", d);
+            }
+            Cow::Borrowed("zip")
+        }
         (decompress, None) => {
             // For a non-archive artifact, the `path` must be part of the cache
             // key. The key has a prefix to distinguish it from the cache keys

--- a/src/fetch_method.rs
+++ b/src/fetch_method.rs
@@ -34,17 +34,21 @@ pub enum ArtifactFormat {
 
     #[serde(rename = "zst")]
     Zstd,
+
+    #[serde(rename = "zip")]
+    Zip,
 }
 
+#[derive(Debug)]
 pub enum DecompressStep {
     Gzip,
     Xz,
     Zstd,
 }
 
-/// Currently, only .tar is supported, though we may support .zip in the future.
 pub enum ArchiveFormat {
     Tar,
+    Zip,
 }
 
 impl ArtifactFormat {
@@ -56,6 +60,7 @@ impl ArtifactFormat {
             Self::TarGz => (Some(DecompressStep::Gzip), Some(ArchiveFormat::Tar)),
             Self::TarXz => (Some(DecompressStep::Xz), Some(ArchiveFormat::Tar)),
             Self::TarZstd => (Some(DecompressStep::Zstd), Some(ArchiveFormat::Tar)),
+            Self::Zip => (None, Some(ArchiveFormat::Zip)),
             Self::Zstd => (Some(DecompressStep::Zstd), None),
         }
     }

--- a/src/print_entry_for_url.rs
+++ b/src/print_entry_for_url.rs
@@ -88,6 +88,8 @@ fn guess_artifact_format_from_url(url: &[u8]) -> ArtifactFormat {
         ArtifactFormat::TarXz
     } else if url.ends_with(b".tar") {
         ArtifactFormat::Tar
+    } else if url.ends_with(b".zip") {
+        ArtifactFormat::Zip
     } else if url.ends_with(b".gz") {
         ArtifactFormat::Gz
     } else if url.ends_with(b".zst") {
@@ -181,6 +183,7 @@ mod tests {
         test("http://example.com/foo.zst.tar", ArtifactFormat::Tar);
         test("http://example.com/foo.gz.tar", ArtifactFormat::Tar);
 
+        test("http://example.com/foo.zip", ArtifactFormat::Zip);
         test("http://example.com/foo", ArtifactFormat::Plain);
         test("http://example.com/foo.bar", ArtifactFormat::Plain);
         test("http://example.com/foo.zstd", ArtifactFormat::Plain);

--- a/website/docs/dotslash-file.md
+++ b/website/docs/dotslash-file.md
@@ -327,6 +327,7 @@ properties:
 | `tar.xz`  | yes      | xz          |
 | `tar.zst` | yes      | zstd        |
 | `tar`     | yes      | _none_      |
+| `zip`     | yes      | zip         |
 | `gz`      | no       | gzip        |
 | `xz`      | no       | xz          |
 | `zst`     | no       | zstd        |


### PR DESCRIPTION
Similarly to #12, this adds support for .zip archives.
Examples of projects using zip only:
- [dprint](https://github.com/dprint/dprint/releases) (per #8)
- [Windows builds of Zig](https://ziglang.org/download/)
 

The code differentiates between the decompression step
(e.g. xz gzip, etc.) and the archive format (e.g. tar, zip).
So unlike .tar.gz, this adds a new ArchiveFormat.

In match arms, this adds the possibility of attempting to handle
.zip.gz or similar, but that's not allowed at the entry point,
so the code errors or panics if it encounters that.

To keep the file size down, the default features of the zip crate
were disabled.
Namely, support for encrypted archives and bzip2 was left out.
Based on my read of [this summary of history of archive formats][1],
this configuration should be sufficient for a vast majority of zip files.

[1]: https://stackoverflow.com/a/20765054

There's also a 'time' feature flag that enables integration
with the [time crate](https://github.com/time-rs/time)
that was also left out.

**File size impact:**

```
❯ git checkout main
❯ cargo build --release
❯ wc -c target/release/dotslash
  985208 target/release/dotslash

❯ git checkout zip
❯ cargo build --release
❯ wc -c target/release/dotslash
 1018312 target/release/dotslash
```

Currently, this change adds 33,104 bytes to the binary size on macOS.
Enabling the (currently disabled) bzip2 feature flag would add another 33,232 bytes.
Disabling the (currently enabled) zstd flag does not reduce the file size.

**License:** zip-rs is licensed under MIT, so it's safe to use here.

**Testing**:
Besides accompanying unit tests,
tested manually with the following file per #8:

```

{
  "name": "dprint",
  "platforms": {
    "macos-aarch64": {
      "size": 7030235,
      "hash": "blake3",
      "digest": "a16c60d1692ad21e12f9d7b167b3dc9d4e5f34c2c1afd5e705842f5ab3e94e0e",
      "format": "zip",
      "path": "dprint",
      "providers": [
        {
          "url": "https://github.com/dprint/dprint/releases/download/0.45.0/dprint-aarch64-apple-darwin.zip"
        }
      ]
    }
  }
}
```

Resolves #8
