### PR TITLE
allow one-line install of the latest version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,13 +33,13 @@ jobs:
       - run: cargo build --release --target aarch64-apple-darwin
       - run: cargo build --release --target x86_64-apple-darwin
       - run: lipo -create -output dotslash target/aarch64-apple-darwin/release/dotslash target/x86_64-apple-darwin/release/dotslash
-      - run: tar -czvf "dotslash-macos.${GITHUB_REF#refs/tags/}.tar.gz" dotslash
+      - run: tar -czvf dotslash-macos.tar.gz --options gzip:compression-level=9 dotslash
         shell: bash
       - name: upload release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
-        run: gh release upload "${GITHUB_REF#refs/tags/}" "dotslash-macos.${GITHUB_REF#refs/tags/}.tar.gz"
+        run: gh release upload "${GITHUB_REF#refs/tags/}" dotslash-macos.tar.gz
 
   ubuntu-22_04-x86_64:
     needs: create-release
@@ -51,12 +51,12 @@ jobs:
       - run: cargo test
       - run: cargo clippy
       - run: cargo build --release
-      - run: tar -czvf "dotslash-ubuntu-22.04.x86_64.${GITHUB_REF#refs/tags/}.tar.gz" -C target/release dotslash
+      - run: tar -cvf dotslash-ubuntu-22.04.x86_64.tar.gz -I 'gzip -9' -C target/release dotslash
       - name: upload release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
-        run: gh release upload "${GITHUB_REF#refs/tags/}" "dotslash-ubuntu-22.04.x86_64.${GITHUB_REF#refs/tags/}.tar.gz"
+        run: gh release upload "${GITHUB_REF#refs/tags/}" dotslash-ubuntu-22.04.x86_64.tar.gz
 
   ubuntu-22_04-arm64:
     needs: create-release
@@ -74,12 +74,12 @@ jobs:
       - run: cargo build --target aarch64-unknown-linux-gnu --release
         env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
-      - run: tar -czvf "dotslash-ubuntu-22.04.arm64.${GITHUB_REF#refs/tags/}.tar.gz" -C target/aarch64-unknown-linux-gnu/release dotslash
+      - run: tar -cvf dotslash-ubuntu-22.04.aarch64.tar.gz -I 'gzip -9' -C target/aarch64-unknown-linux-gnu/release dotslash
       - name: upload release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
-        run: gh release upload "${GITHUB_REF#refs/tags/}" "dotslash-ubuntu-22.04.arm64.${GITHUB_REF#refs/tags/}.tar.gz"
+        run: gh release upload "${GITHUB_REF#refs/tags/}" dotslash-ubuntu-22.04.aarch64.tar.gz
 
   windows:
     needs: create-release
@@ -91,10 +91,10 @@ jobs:
       - run: cargo test
       - run: cargo clippy
       - run: cargo build --release
-      - run: tar czvf dotslash-windows.%GITHUB_REF:~10%.tar.gz -C target/release dotslash.exe
+      - run: tar czvf dotslash-windows.tar.gz --options gzip:compression-level=9 -C target/release dotslash.exe
         shell: cmd
       - name: upload release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload %GITHUB_REF:~10% dotslash-windows.%GITHUB_REF:~10%.tar.gz
+        run: gh release upload %GITHUB_REF:~10% dotslash-windows.tar.gz
         shell: cmd

--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -23,7 +23,20 @@ We provide prebuilt binaries for macOS, [Ubuntu] Linux, and Windows on GitHub:
 
 <https://github.com/facebook/dotslash/releases/latest>
 
-For the reasons explained above, the macOS release is a Universal Binary.
+macOS: for the reasons explained above, the macOS release is a Universal Binary.
+```shell
+curl -LSfs https://github.com/facebook/dotslash/releases/latest/download/dotslash-macos.tar.gz | tar fxz - -C YOUR_BIN_PATH
+```
+
+Linux
+```shell
+curl -LSfs "https://github.com/facebook/dotslash/releases/latest/download/dotslash-ubuntu-22.04.$(uname -m).tar.gz" | tar fxz - -C YOUR_BIN_PATH
+```
+
+Windows
+```cmd
+cmd /c 'curl.exe -LSfs https://github.com/facebook/dotslash/releases/latest/download/dotslash-windows.tar.gz | tar fxz - -C YOUR_BIN_PATH'
+```
 
 Once you have downloaded DotSlash, you must ensure that `dotslash` (or
 `dotslash.exe` on Windows) is on your `PATH`. You can test that it is setup


### PR DESCRIPTION
- remove version from filename and rename arm64 to aarch64 (uname -m) for one-line install
- version-pinned urls are still avaiable as https://github.com/facebook/dotslash/releases/download/v0.3.0/dotslash-macos.tar.gz
- maximize gzip compression level