### PR TITLE
Release statically linked executables on Linux

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,6 +81,52 @@ jobs:
         shell: bash
         run: gh release upload "${GITHUB_REF#refs/tags/}" "dotslash-ubuntu-22.04.arm64.${GITHUB_REF#refs/tags/}.tar.gz"
 
+  linux-musl-x86_64:
+    needs: create-release
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-unknown-linux-musl
+      - name: Install musl build tools
+        run: |
+          sudo apt update
+          sudo apt install -y musl-tools
+      - run: cargo test
+      - run: cargo clippy
+      - run: cargo build --target x86_64-unknown-linux-musl --release
+      - run: tar -czvf "dotslash-linux-musl.x86_64.${GITHUB_REF#refs/tags/}.tar.gz" -C target/x86_64-unknown-linux-musl/release dotslash
+      - name: upload release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: gh release upload "${GITHUB_REF#refs/tags/}" "dotslash-linux-musl.x86_64.${GITHUB_REF#refs/tags/}.tar.gz"
+
+  linux-musl-arm64:
+    needs: create-release
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-unknown-linux-musl
+      - name: Install aarch64 musl build tools
+        run: |
+          sudo apt update
+          sudo apt install -y musl-tools gcc-aarch64-linux-gnu
+      - run: cargo build --target aarch64-unknown-linux-musl --release
+        env:
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+      - run: tar -czvf "dotslash-linux-musl.arm64.${GITHUB_REF#refs/tags/}.tar.gz" -C target/aarch64-unknown-linux-musl/release dotslash
+      - name: upload release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: gh release upload "${GITHUB_REF#refs/tags/}" "dotslash-linux-musl.arm64.${GITHUB_REF#refs/tags/}.tar.gz"
+
   windows:
     needs: create-release
     runs-on: windows-latest


### PR DESCRIPTION
One of the major benefits of dotslash is to be used to bootstrap other tools on pretty much any system. Unfortunately when it comes to linux the executables included in the release are built on Ubuntu 22.04 which means that they link a fairly modern glibc. Trying to use the executable on an older Ubuntu (or any other flavor of Linux that doesn't use glibc) will fail due to linking errors.

We could instead build the binary on a super old linux version but Github only goes back to 20.04 so instead let's produce a fully static executable that statically links the musl libc.

This is a common pattern that many tools built for linux adopt and it will greatly simplify the adoption on linux distros that don't repackage dotslash.