### PR TITLE
[release] Fix cross-compilation of musl build for aarch64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,13 +113,11 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: aarch64-unknown-linux-musl
-      - name: Install aarch64 musl build tools
-        run: |
-          sudo apt update
-          sudo apt install -y musl-tools gcc-aarch64-linux-gnu
-      - run: cargo build --target aarch64-unknown-linux-musl --release
-        env:
-          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+      - uses: actions-rs/install@v0.1
+        with:
+          crate: cross
+          version: latest
+      - run: cross build --target aarch64-unknown-linux-musl --release
       - run: tar -czvf "dotslash-linux-musl.arm64.${GITHUB_REF#refs/tags/}.tar.gz" -C target/aarch64-unknown-linux-musl/release dotslash
       - name: upload release
         env:


### PR DESCRIPTION
Hey @zertosh I noticed that dotslash 0.4.2 [failed to build](https://github.com/facebook/dotslash/actions/runs/11298708954/job/31428236384) the aarch64 variant of the musl binary and it turns out that cross-compiling an aarch64 Rust binary that links musl on x86_64 doesn't just work and requires some extra setup. Luckily there's a crate `cross` that does all this for us (and that I realized buck2 also happens to use to build aarch64 binaries) so use that instead!

I've validated that building on my x86_64 machine now works as expected.