### PR TITLE
Add option to pass path of downloaded executable as argv0

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -28,6 +28,12 @@ pub const REQUIRED_HEADER: &str = "#!/usr/bin/env dotslash";
 pub struct ConfigFile {
     pub name: String,
     pub platforms: HashMap<String, ArtifactEntry>,
+    #[serde(default = "default_preserve_arg0")]
+    pub preserve_arg0: bool,
+}
+
+fn default_preserve_arg0() -> bool {
+    true
 }
 
 #[derive(Deserialize, Serialize, Debug, PartialEq)]

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -72,13 +72,15 @@ fn run_dotslash_file<P: ProviderFactory>(
     };
 
     let dotslash_cache = DotslashCache::new();
-    let (artifact_entry, artifact_location) = locate_artifact(&dotslash_data, &dotslash_cache)?;
+    let (artifact_entry, artifact_location, preserve_arg0) = locate_artifact(&dotslash_data, &dotslash_cache)?;
 
     let mut command = Command::new(&artifact_location.executable);
     command.args(args);
 
-    #[cfg(unix)]
-    std::os::unix::process::CommandExt::arg0(&mut command, file_arg);
+    if preserve_arg0 {
+        #[cfg(unix)]
+        std::os::unix::process::CommandExt::arg0(&mut command, file_arg);
+    }
 
     let error = util::execv(&mut command);
 

--- a/src/locate.rs
+++ b/src/locate.rs
@@ -21,7 +21,7 @@ use crate::util::ListOf;
 pub fn locate_artifact(
     dotslash_data: &str,
     dotslash_cache: &DotslashCache,
-) -> anyhow::Result<(ArtifactEntry, ArtifactLocation)> {
+) -> anyhow::Result<(ArtifactEntry, ArtifactLocation, bool)> {
     let (_original_json, mut config_file) =
         config::parse_file(dotslash_data).context("failed to parse DotSlash file")?;
 
@@ -50,5 +50,5 @@ pub fn locate_artifact(
         let _ = util::update_mtime(&artifact_location.executable);
     }
 
-    Ok((artifact_entry, artifact_location))
+    Ok((artifact_entry, artifact_location, config_file.preserve_arg0))
 }

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -167,7 +167,7 @@ fn _run_subcommand(subcommand: &Subcommand, args: &mut ArgsOs) -> anyhow::Result
             let file_arg = take_exactly_one_arg(args)?;
             let dotslash_data = fs_ctx::read_to_string(file_arg)?;
             let dotslash_cache = DotslashCache::new();
-            let (artifact_entry, artifact_location) =
+            let (artifact_entry, artifact_location, _) =
                 locate_artifact(&dotslash_data, &dotslash_cache)?;
             if !artifact_location.executable.exists() {
                 let provider_factory = DefaultProviderFactory {};

--- a/website/docs/dotslash-file.md
+++ b/website/docs/dotslash-file.md
@@ -106,6 +106,7 @@ The general structure of a DotSlash file is:
 {
   "name": /* string */,
   "platforms": /* map */,
+  "preserve_arg0": /* boolean */,
 }
 ```
 
@@ -117,6 +118,10 @@ properties:
 - `"name"` must be a string that represents the name of the executable (it often
   matches the name of the DotSlash file)
 - `"platforms"` must be a map of supported platforms to artifacts
+- `"preserve_arg0"` [optional] may be a boolean specifying whether to preserve
+  the zeroth argument passed to `dotslash` itself (`true`, the default), or to
+  instead pass the path to the executable in the Dotslash cache (`false`). See
+  [Preserve arg0](#preserve-arg0).
 
 :::tip
 
@@ -434,3 +439,20 @@ DotSlash file may not be in a position to change that.
 In this case, setting `readonly: false` will disable the logic that marks all of
 the entries in the temporary folder read-only before it is moved to its final
 location in the cache.
+
+## Preserve arg0
+
+There is an optional `preserve_arg0` field on the root object in a Dotslash file
+that specifies what is passed as the zeroth argument (`argv[0]`) to the
+underlying process. The options are:
+
+- `"preserve_arg0": true` - This forwards the zeroth argument of the outer
+  invocation of `dotslash`. This can be useful for executables that will use the
+  zeroth argument to modify their behavior or behave as different commands, such
+  as `clang` or GNU coreutils. This is the default.
+- `"preserve_arg0": false` - This passes the path to the executable in the
+  dotslash cache as the zeroth argument. This can be useful for executables that
+  will use `argv[0]` to locate the path of related files in the same archive, or
+  parse trailing data attached to the executable file.
+
+This option has no effect on Windows.


### PR DESCRIPTION
Some programs will read `argv[0]` to find related files in the extracted archive, or to parse data attached to the end of the executable. However by default Dotslash passes the path to the original dotslash file as `argv[0]`, which prevents this from working.

However some programs will also read `argv[0]` and use this to modify their behaviour, such as when the same executable can behave as many independent commands (eg GNU coreutils) or where it may act differently as it is impersonating another program (`clang` when invoked as `clang-cl`).

Therefore this should be an option, some programs will need either behaviour.

The motivating example is https://github.com/facebook/dotslash/issues/22, where writing a Dotslash file for https://github.com/indygreg/python-build-standalone doesn't work unless `argv[0]` is the path to the file within the extracted archive.