### PR TITLE
docs: Fix link to windows_shim

### DIFF
--- a/website/docs/windows.md
+++ b/website/docs/windows.md
@@ -77,9 +77,9 @@ for easy execution without any of the drawbacks of batch scripts. But this
 method requires compiling a small executable and keeping it next to the DotSlash
 file.
 
-The _DotSlash Windows Shim_ will be made available to the public shortly under
-the [`windows_shim`](https://github.com/facebook/dotslash/windows_shim) in the
-[DotSlash GitHub repository](https://github.com/facebook/dotslash).
+The _DotSlash Windows Shim_ is available under the
+[`windows_shim`](https://github.com/facebook/dotslash/tree/main/windows_shim) folder
+in the [DotSlash GitHub repository](https://github.com/facebook/dotslash).
 
 ## `MAX_PATH` limits
 


### PR DESCRIPTION
The link was a 404. This commit also changes some wording, since it's already available.