### PR TITLE
Pass through stderr in case of non-zero exit code from gh provider

### DIFF
--- a/src/github_release_provider.rs
+++ b/src/github_release_provider.rs
@@ -35,7 +35,7 @@ impl Provider for GitHubReleaseProvider {
         _artifact_entry: &ArtifactEntry,
     ) -> anyhow::Result<()> {
         let GitHubReleaseProviderConfig { tag, repo, name } = <_>::deserialize(provider_config)?;
-        let _output = Command::new("gh")
+        let output = Command::new("gh")
             .arg("release")
             .arg("download")
             .arg(tag)
@@ -48,8 +48,18 @@ impl Provider for GitHubReleaseProvider {
             .arg(regex_escape(&name))
             .arg("--output")
             .arg(destination)
-            .output()?;
-        Ok(())
+            .output()
+            .unwrap();
+
+        if output.status.success() {
+            Ok(())
+        } else {
+            Err(anyhow::anyhow!(
+                "failed to download release with exit code {} and stderr: {}",
+                output.status.code().unwrap(),
+                String::from_utf8_lossy(&output.stderr)
+            ))
+        }
     }
 }
 


### PR DESCRIPTION
This patch ensures that errors from gh propagate upwards and to the user to improve debugging.

Specifically this fixes the case where debug info is swallowed related to being un-authed to gh binary but left with unclear error message.

Running the debug build when un-authed for gh:

```
❯ ~/src/dotslash-packages/jq
dotslash error: problem with `/Users/zph/src/dotslash-packages/jq`
caused by: failed to download artifact into cache `/Users/zph/Library/Caches/dotslash` artifact location `/Users/zph/Library/Caches/dotslash/cb/f59eb5aa25d6175aeb330d10532306112753da`
caused by: no providers succeeded. warnings:
failed to fetch artifact: failed to download release with exit code 4 and stderr: To get started with GitHub CLI, please run:  gh auth login
Alternatively, populate the GH_TOKEN environment variable with a GitHub API authentication token.
```

Which is superior to existing error message in #42 .

Closes #42 

### TODO

- [ ] Ensure it meets style guidelines
- [x] Sign CLA
- [ ] Define invariants are agreed upon (do this in case of non-zero exit code)