### PR TITLE
[RFC] config: Support provider randomization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,6 +288,8 @@ dependencies = [
  "flate2",
  "fs2",
  "nix",
+ "rand",
+ "rand_chacha",
  "serde",
  "serde_jsonrc",
  "sha2",
@@ -524,6 +526,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -539,6 +550,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.1",
 ]
 
 [[package]]
@@ -1046,6 +1085,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
 dependencies = [
  "lzma-sys",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ dunce = "1.0.2"
 filetime = "0.2.9"
 flate2 = { version = "1.0.33", features = ["rust_backend"], default-features = false }
 fs2 = "0.4"
-rand = { version = "0.9.1", default-features = false }
+rand = { version = "0.9.1", default-features = false, features = ["alloc"] }
 rand_chacha = { version = "0.9.0", default-features = false, features = ["os_rng"] }
 serde = { version = "1.0.185", features = ["derive", "rc"] }
 serde_jsonrc = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ dunce = "1.0.2"
 filetime = "0.2.9"
 flate2 = { version = "1.0.33", features = ["rust_backend"], default-features = false }
 fs2 = "0.4"
+rand = { version = "0.9.1", default-features = false }
+rand_chacha = { version = "0.9.0", default-features = false, features = ["os_rng"] }
 serde = { version = "1.0.185", features = ["derive", "rc"] }
 serde_jsonrc = "0.1"
 sha2 = "0.10.6"

--- a/src/artifact_location.rs
+++ b/src/artifact_location.rs
@@ -64,6 +64,7 @@ pub fn determine_location(
         providers: _,
         arg0,
         readonly,
+        providers_order: _,
     } = artifact_entry;
 
     let artifact_hash = blake3::Hasher::new()
@@ -135,7 +136,7 @@ fn create_key_for_format(format: ArtifactFormat, path: &ArtifactPath) -> Cow<'st
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::digest::Digest;
+    use crate::{config::ProvidersOrder, digest::Digest};
 
     #[test]
     fn paths_for_extract_case() {
@@ -151,6 +152,7 @@ mod tests {
             providers: vec![],
             arg0: Arg0::DotslashFile,
             readonly: true,
+            providers_order: ProvidersOrder::Sequential,
         };
         let dotslash_cache = DotslashCache::default();
         let location = determine_location(&artifact_entry, &dotslash_cache);
@@ -191,6 +193,7 @@ mod tests {
             path: "minesweeper.exe".parse().unwrap(),
             providers: vec![],
             arg0: Arg0::DotslashFile,
+            providers_order: ProvidersOrder::Sequential,
             readonly: true,
         };
         let dotslash_cache = DotslashCache::default();

--- a/src/config.rs
+++ b/src/config.rs
@@ -46,6 +46,8 @@ pub struct ArtifactEntry<Format = ArtifactFormat> {
     pub arg0: Arg0,
     #[serde(default = "readonly_default_as_true", skip_serializing_if = "is_true")]
     pub readonly: bool,
+    #[serde(default, skip_serializing_if = "is_default")]
+    pub providers_order: ProvidersOrder,
 }
 
 fn is_default<T>(t: &T) -> bool
@@ -67,6 +69,18 @@ pub enum Arg0 {
     /// arg0 is left unset, which defaults to the underlying executable
     /// in the cache directory.
     UnderlyingExecutable,
+}
+
+/// Determines the order in which providers are tried
+/// when multiple providers are available.
+#[derive(Deserialize, Serialize, Copy, Clone, Default, Debug, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum ProvidersOrder {
+    /// Try each provider in the order they are listed in the DotSlash file.
+    #[default]
+    Sequential,
+    /// Try providers in a random order.
+    Random,
 }
 
 /// While having a boolean that defaults to `true` is somewhat undesirable,
@@ -159,11 +173,70 @@ mod tests {
                             "url": "https://example.com/my_tool.tar",
                         })],
                         arg0: Arg0::DotslashFile,
+                        providers_order: ProvidersOrder::Sequential,
                         readonly: true,
                     }
                 )]
                 .into(),
             },
+        );
+    }
+
+    #[test]
+    fn providers_order_sequential_explicit() {
+        let dotslash = r#"#!/usr/bin/env dotslash
+        {
+            "name": "my_tool",
+            "platforms": {
+                "linux-x86_64": {
+                    "size": 123,
+                    "hash": "sha256",
+                    "digest": "7f83b1657ff1fc53b92dc18148a1d65dfc2d4b1fa3d677284addd200126d9069",
+                    "path": "bindir/my_tool",
+                    "providers": [
+                        {
+                            "type": "http",
+                            "url": "https://example.com/my_tool.tar"
+                        }
+                    ],
+                    "providers_order": "sequential"
+                },
+            },
+        }
+        "#;
+        let config_file = parse_file_string(dotslash).unwrap();
+        assert_eq!(
+            config_file.platforms["linux-x86_64"].providers_order,
+            ProvidersOrder::Sequential
+        );
+    }
+
+    #[test]
+    fn providers_order_random() {
+        let dotslash = r#"#!/usr/bin/env dotslash
+        {
+            "name": "my_tool",
+            "platforms": {
+                "linux-x86_64": {
+                    "size": 123,
+                    "hash": "sha256",
+                    "digest": "7f83b1657ff1fc53b92dc18148a1d65dfc2d4b1fa3d677284addd200126d9069",
+                    "path": "bindir/my_tool",
+                    "providers": [
+                        {
+                            "type": "http",
+                            "url": "https://example.com/my_tool.tar"
+                        }
+                    ],
+                    "providers_order": "random"
+                },
+            },
+        }
+        "#;
+        let config_file = parse_file_string(dotslash).unwrap();
+        assert_eq!(
+            config_file.platforms["linux-x86_64"].providers_order,
+            ProvidersOrder::Random
         );
     }
 
@@ -210,6 +283,7 @@ mod tests {
                             "url": "https://foo.com",
                         })],
                         arg0: Arg0::DotslashFile,
+                        providers_order: ProvidersOrder::Sequential,
                         readonly: true,
                     }
                 )]

--- a/src/config.rs
+++ b/src/config.rs
@@ -79,8 +79,12 @@ pub enum ProvidersOrder {
     /// Try each provider in the order they are listed in the DotSlash file.
     #[default]
     Sequential,
-    /// Try providers in a random order.
-    Random,
+    /// Try providers in a random order,
+    /// using the "weight" key on each provider
+    /// to determine the probability of selection.
+    //
+    /// If no "weight" key is present, all providers are equally likely.
+    WeightedRandom,
 }
 
 /// While having a boolean that defaults to `true` is somewhat undesirable,
@@ -228,7 +232,7 @@ mod tests {
                             "url": "https://example.com/my_tool.tar"
                         }
                     ],
-                    "providers_order": "random"
+                    "providers_order": "weighted-random"
                 },
             },
         }
@@ -236,7 +240,7 @@ mod tests {
         let config_file = parse_file_string(dotslash).unwrap();
         assert_eq!(
             config_file.platforms["linux-x86_64"].providers_order,
-            ProvidersOrder::Random
+            ProvidersOrder::WeightedRandom,
         );
     }
 

--- a/src/download.rs
+++ b/src/download.rs
@@ -392,4 +392,32 @@ mod tests {
             vec![&providers[2], &providers[3], &providers[1], &providers[0]]
         );
     }
+
+    #[test]
+    fn providres_in_order_weighted_random_zero_weight() {
+        let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(42); // deterministic for testing
+
+        let providers = vec![
+            serde_jsonrc::from_str(r#"{"type": "a", "weight": 0}"#).unwrap(),
+            serde_jsonrc::from_str(r#"{"type": "b", "weight": 2}"#).unwrap(),
+        ];
+
+        let result = providers_in_order(&mut rng, &providers, ProvidersOrder::WeightedRandom);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("weight must be greater than 0"));
+    }
+
+    #[test]
+    fn providers_in_order_weighted_random_negative_weight() {
+        let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(42); // deterministic for testing
+
+        let providers = vec![
+            serde_jsonrc::from_str(r#"{"type": "a", "weight": -1}"#).unwrap(),
+            serde_jsonrc::from_str(r#"{"type": "b", "weight": 2}"#).unwrap(),
+        ];
+
+        let result = providers_in_order(&mut rng, &providers, ProvidersOrder::WeightedRandom);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("weight must be a non-negative integer"));
+    }
 }

--- a/src/print_entry_for_url.rs
+++ b/src/print_entry_for_url.rs
@@ -19,6 +19,7 @@ use tempfile::NamedTempFile;
 use crate::config::Arg0;
 use crate::config::ArtifactEntry;
 use crate::config::HashAlgorithm;
+use crate::config::ProvidersOrder;
 use crate::curl::CurlCommand;
 use crate::curl::FetchContext;
 use crate::fetch_method::ArtifactFormat;
@@ -67,6 +68,7 @@ fn serialize_entry(url: &str, size: u64, hex_digest: String) -> anyhow::Result<S
         path: "TODO: specify the appropriate `path` for this artifact".parse()?,
         providers: vec![serde_jsonrc::json!({"url": url})],
         arg0: Arg0::default(),
+        providers_order: ProvidersOrder::Sequential,
         readonly: true,
     };
     let entry_json = serde_jsonrc::to_string_pretty(&entry)?;
@@ -119,6 +121,7 @@ mod tests {
                 path: "TODO: specify the appropriate `path` for this artifact".parse()?,
                 providers: vec![serde_jsonrc::json!({"url": url})],
                 arg0: Arg0::DotslashFile,
+                providers_order: ProvidersOrder::Sequential,
                 readonly: true,
             },
             entry,

--- a/website/docs/dotslash-file.md
+++ b/website/docs/dotslash-file.md
@@ -206,11 +206,28 @@ Currently, DotSlash supports two providers out of the box: the **HTTP Provider**
 (`"type": "github-release"`). (At the time of this writing, there is no way to
 add custom providers without forking DotSlash.)
 
-Each provider in the `providers` list will be tried, in order, to fetch the
+Each provider in the `providers` list will be tried, in order by default, to fetch the
 artifact, until one succeeds. The provider type need not be unique within a
 list, e.g., the HTTP Provider can be specified multiple times with different
 values for `"url"`. Though note that the `size`/`hash`/`digest` are specified
 _independently_ of the providers, so all providers must yield the same artifact.
+
+The order in which providers are tried can be randomized
+by adding `providers_order: "random"` under the artifact entry.
+
+```json
+{
+  ...
+  "format": "tar.gz",
+  "path": "hermes",
+  "providers": [
+    {"url": "https://mirror1.example.com/hermes.tar.gz"},
+    {"url": "https://mirror2.example.com/hermes.tar.gz"},
+    {"url": "https://mirror3.example.com/hermes.tar.gz"}
+  ],
+  "providers_order": "random"
+}
+```
 
 ### HTTP Provider
 

--- a/website/docs/dotslash-file.md
+++ b/website/docs/dotslash-file.md
@@ -213,7 +213,10 @@ values for `"url"`. Though note that the `size`/`hash`/`digest` are specified
 _independently_ of the providers, so all providers must yield the same artifact.
 
 The order in which providers are tried can be randomized
-by adding `providers_order: "random"` under the artifact entry.
+by adding `providers_order: "weighted-random"` under the artifact entry.
+This will randomize the order in which providers are tried,
+using an optional `weight` for each provider to bias the selection.
+For example:
 
 ```json
 {
@@ -221,13 +224,21 @@ by adding `providers_order: "random"` under the artifact entry.
   "format": "tar.gz",
   "path": "hermes",
   "providers": [
-    {"url": "https://mirror1.example.com/hermes.tar.gz"},
-    {"url": "https://mirror2.example.com/hermes.tar.gz"},
-    {"url": "https://mirror3.example.com/hermes.tar.gz"}
+    {"url": "https://primary.example.com/hermes.tar.gz", "weight": 3},
+    {"url": "https://mirror1.example.com/hermes.tar.gz", "weight": 1},
+    {"url": "https://mirror2.example.com/hermes.tar.gz", "weight": 1},
+    {"url": "https://mirror3.example.com/hermes.tar.gz", "weight": 1}
   ],
-  "providers_order": "random"
+  "providers_order": "weighted-random"
 }
 ```
+
+In this example, the primary provider is more likely to be tried first,
+but the remaining three mirrors are equally likely to be tried next.
+Providers are not retried if they fail, so the first successful provider wins.
+
+The weight must be an integer value greater than or equal to `1`.
+If weight is not specified for a provider, it defaults to `1`.
 
 ### HTTP Provider
 


### PR DESCRIPTION
**Proposed change**

This changes the dotslash file schema to add a new optional field:

```diff
 {
     // ...
     providers: [ ... ]
+    providers_order: "sequential" | "weighted-random",
 }
```

The default ("sequential") will try the providers in the order
they are specified in the 'providers' list.
This is how dotslash behaves today.

If the value is "weighted-random",
the order in which providers are tried will be randomized.

By default, all providers will be weighted equally.
This can be changed by adding a `"weight"` value
to the provider configuration:

```json
    {"url": "https://primary.example.com/hermes.tar.gz", "weight": 3},
    {"url": "https://mirror1.example.com/hermes.tar.gz", "weight": 1},
    {"url": "https://mirror2.example.com/hermes.tar.gz", "weight": 1},
    {"url": "https://mirror3.example.com/hermes.tar.gz", "weight": 1}
```

Weight must be an integer >=1.
Zero ("don't select") is not permitted.

To shuffle providers in weighted order, they are sampled without replacement.
That is, even if the weight of a provider would present it twice before another option,
it is not re-added to the final order of providers—it is tried only once.

**Why**

This will result in better usage patterns
when there are multiple providers for an executable.
As an example, for the [Zig compiler](https://ziglang.org/),
while there's an officially hosted source,
it's preferred to use third-party mirrors
(https://github.com/mlugg/setup-zig/blob/153c8d5202cbb8c7e10831110a3afd27593eb960/mirrors.json)
to avoid hammering the official server.

**Binary size**

This adds ~16 KB to the output of `cargo build --release` on macOS ARM64:

    Before  1103440 bytes
    After   1120000 bytes
    ------- -------------
    Change    16560 bytes

Resolves #33
