### PR TITLE
Add support for .bz2 and .tar.bz2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,6 +148,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "bzip2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
+dependencies = [
+ "bzip2-sys",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -275,6 +294,7 @@ dependencies = [
  "assert_matches",
  "blake3",
  "buck-resources",
+ "bzip2",
  "digest",
  "dirs",
  "dunce",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ path = "tests/dotslash_tests.rs"
 [dependencies]
 anyhow = "1.0.95"
 blake3 = { version = "=1.5.5", features = ["mmap", "rayon", "traits-preview"] }
+bzip2 = { version = "0.5.2", features = ["static"] }
 digest = "0.10"
 dirs = "6.0"
 dunce = "1.0.2"

--- a/src/artifact_location.rs
+++ b/src/artifact_location.rs
@@ -119,6 +119,7 @@ fn create_key_for_format(format: ArtifactFormat, path: &ArtifactPath) -> Cow<'st
         // key. The key has a prefix to distinguish it from the cache keys
         // for archive artifacts.
         ArtifactFormat::Plain => Cow::Owned(format!("file:{}", path)),
+        ArtifactFormat::Bzip2 => Cow::Owned(format!("file.bz:{}", path)),
         ArtifactFormat::Gz => Cow::Owned(format!("file.gz:{}", path)),
         ArtifactFormat::Xz => Cow::Owned(format!("file.xz:{}", path)),
         ArtifactFormat::Zstd => Cow::Owned(format!("file.zst:{}", path)),
@@ -126,6 +127,7 @@ fn create_key_for_format(format: ArtifactFormat, path: &ArtifactPath) -> Cow<'st
         // For a container artifact, the type of archive is sufficient
         // to distinguish it.
         ArtifactFormat::Tar => Cow::Borrowed("tar"),
+        ArtifactFormat::TarBzip2 => Cow::Borrowed("tar.bz2"),
         ArtifactFormat::TarGz => Cow::Borrowed("tar.gz"),
         ArtifactFormat::TarXz => Cow::Borrowed("tar.xz"),
         ArtifactFormat::TarZstd => Cow::Borrowed("tar.zst"),

--- a/src/fetch_method.rs
+++ b/src/fetch_method.rs
@@ -20,11 +20,17 @@ pub enum ArtifactFormat {
     #[serde(skip)]
     Plain,
 
+    #[serde(rename = "bz2")]
+    Bzip2,
+
     #[serde(rename = "gz")]
     Gz,
 
     #[serde(rename = "tar")]
     Tar,
+
+    #[serde(rename = "tar.bz2")]
+    TarBzip2,
 
     #[serde(rename = "tar.gz")]
     TarGz,
@@ -50,10 +56,12 @@ impl ArtifactFormat {
     pub fn as_archive_type(self) -> Option<ArchiveType> {
         match self {
             Self::Plain => None,
+            Self::Bzip2 => Some(ArchiveType::Bzip2),
             Self::Gz => Some(ArchiveType::Gz),
             Self::Xz => Some(ArchiveType::Xz),
             Self::Zstd => Some(ArchiveType::Zstd),
             Self::Tar => Some(ArchiveType::Tar),
+            Self::TarBzip2 => Some(ArchiveType::TarBzip2),
             Self::TarGz => Some(ArchiveType::TarGz),
             Self::TarXz => Some(ArchiveType::TarXz),
             Self::TarZstd => Some(ArchiveType::TarZstd),
@@ -64,8 +72,8 @@ impl ArtifactFormat {
     #[must_use]
     pub fn is_container(self) -> bool {
         match self {
-            Self::Plain | Self::Gz | Self::Xz | Self::Zstd => false,
-            Self::Tar | Self::TarGz | Self::TarXz | Self::TarZstd | Self::Zip => true,
+            Self::Plain | Self::Bzip2 | Self::Gz | Self::Xz | Self::Zstd => false,
+            Self::Tar | Self::TarBzip2 | Self::TarGz | Self::TarXz | Self::TarZstd | Self::Zip => true,
         }
     }
 }

--- a/src/print_entry_for_url.rs
+++ b/src/print_entry_for_url.rs
@@ -76,7 +76,9 @@ fn serialize_entry(url: &str, size: u64, hex_digest: String) -> anyhow::Result<S
 }
 
 fn guess_artifact_format_from_url(url: &[u8]) -> ArtifactFormat {
-    if url.ends_with(b".tar.gz") || url.ends_with(b".tgz") {
+    if url.ends_with(b".tar.bz2") {
+        ArtifactFormat::TarBzip2
+    } else if url.ends_with(b".tar.gz") || url.ends_with(b".tgz") {
         ArtifactFormat::TarGz
     } else if url.ends_with(b".tar.zst") || url.ends_with(b".tzst") {
         ArtifactFormat::TarZstd
@@ -86,6 +88,8 @@ fn guess_artifact_format_from_url(url: &[u8]) -> ArtifactFormat {
         ArtifactFormat::Tar
     } else if url.ends_with(b".zip") {
         ArtifactFormat::Zip
+    } else if url.ends_with(b".bz2") {
+        ArtifactFormat::Bzip2
     } else if url.ends_with(b".gz") {
         ArtifactFormat::Gz
     } else if url.ends_with(b".xz") {

--- a/src/util/unarchive.rs
+++ b/src/util/unarchive.rs
@@ -13,6 +13,7 @@ use std::io::Read;
 use std::io::Seek;
 use std::path::Path;
 
+use bzip2::read::BzDecoder;
 use flate2::bufread::GzDecoder;
 use tar::Archive;
 #[cfg(not(dotslash_internal))]
@@ -26,6 +27,9 @@ use crate::util::fs_ctx;
 #[derive(Copy, Clone)]
 pub enum ArchiveType {
     Tar,
+    #[cfg(not(dotslash_internal))]
+    Bzip2,
+    TarBzip2,
     #[cfg(not(dotslash_internal))]
     Gz,
     TarGz,
@@ -52,6 +56,10 @@ where
 {
     match archive_type {
         ArchiveType::Tar => unpack_tar(reader, destination),
+
+        #[cfg(not(dotslash_internal))]
+        ArchiveType::Bzip2 => write_out(BzDecoder::new(reader), destination),
+        ArchiveType::TarBzip2 => unpack_tar(BzDecoder::new(reader), destination),
 
         #[cfg(not(dotslash_internal))]
         ArchiveType::Gz => write_out(GzDecoder::new(reader), destination),

--- a/website/docs/dotslash-file.md
+++ b/website/docs/dotslash-file.md
@@ -352,11 +352,13 @@ properties:
 
 | `format`  | Archive? | Decompress? |
 | --------- | -------- | ----------- |
+| `tar.bz2` | yes      | bzip2       |
 | `tar.gz`  | yes      | gzip        |
 | `tar.xz`  | yes      | xz          |
 | `tar.zst` | yes      | zstd        |
 | `tar`     | yes      | _none_      |
 | `zip`     | yes      | zip         |
+| `bz2`     | no       | bzip2       |
 | `gz`      | no       | gzip        |
 | `xz`      | no       | xz          |
 | `zst`     | no       | zstd        |


### PR DESCRIPTION

Summary:
I was looking to use dotslash for dhall, but they only distribute
their binaries in .tar.bz files, which dotslash didn't support.

Slightly weird to me that this wasn't implemented already, but whatever.

Logic is copied from existing compression format implementations.

Test Plan: Minimal dotslash file:

```
#!/usr/bin/env dotslash

{
  "name": "dhall",
  "platforms": {
    "linux-x86_64": {
      "size": 7085140,
      "hash": "blake3",
      "digest": "183a542748b4c5319b947fc759ae3c03b32b34d346d0c9003aa4186b91defd21",
      "format": "tar.bz2",
      "path": "bin/dhall",
      "providers": [
        {
          "url": "https://github.com/dhall-lang/dhall-haskell/releases/download/1.42.2/dhall-1.42.2-x86_64-linux.tar.bz2"
        },
        {
          "type": "github-release",
          "repo": "dhall-lang/dhall-haskell",
          "tag": "1.42.2",
          "name": "dhall-1.42.2-x86_64-linux.tar.bz2"
        }
      ]
    }
  }
}
```
