### PR TITLE
feat: deploy feature to facebook/devcontainers/features instead of facebook/dotslash

### DIFF
--- a/.github/workflows/release-feature.yml
+++ b/.github/workflows/release-feature.yml
@@ -20,4 +20,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           base-path-to-features: ./devcontainer-features/src
+          features-namespace: ${{ github.repository_owner }}/devcontainers/features
           publish-features: "true"


### PR DESCRIPTION
This should be better than the current deployment situation.  All of this lacks documentation, however, so it's also a bit of experimentation, alas.