### PR TITLE
fix: use macos-latest instead of macos-14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,9 +9,9 @@ jobs:
   build:
     strategy:
       matrix:
-        # macos-13 appears to be x86 while macos-14 is M1
+        # macos-13 appears to be x86 while macos-latest is arm64
         # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners
-        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
+        os: [ubuntu-latest, windows-latest, macos-13, macos-latest]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     steps:


### PR DESCRIPTION
These are both arm64, but we should be testing on a newer OS.