### PR TITLE
feat: allow one-line install of the latest version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,12 +34,12 @@ jobs:
       - run: cargo build --release --target x86_64-apple-darwin
       - run: lipo -create -output dotslash target/aarch64-apple-darwin/release/dotslash target/x86_64-apple-darwin/release/dotslash
       # Package universal binary
-      - run: tar -czvf "dotslash-macos.tar.gz" dotslash
+      - run: tar -czvf dotslash-macos.tar.gz --options gzip:compression-level=9 dotslash
         shell: bash
       # Package architecture-specific binaries
-      - run: tar -czvf "dotslash-macos-arm64.tar.gz" -C target/aarch64-apple-darwin/release dotslash
+      - run: tar -czvf dotslash-macos-arm64.tar.gz -C target/aarch64-apple-darwin/release --options gzip:compression-level=9 dotslash
         shell: bash
-      - run: tar -czvf "dotslash-macos-x86_64.tar.gz" -C target/x86_64-apple-darwin/release dotslash
+      - run: tar -czvf dotslash-macos-x86_64.tar.gz -C target/x86_64-apple-darwin/release --options gzip:compression-level=9 dotslash
         shell: bash
       # Upload all binaries
       - name: upload release
@@ -47,9 +47,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: |
-          gh release upload "${GITHUB_REF#refs/tags/}" "dotslash-macos.tar.gz"
-          gh release upload "${GITHUB_REF#refs/tags/}" "dotslash-macos-arm64.tar.gz"
-          gh release upload "${GITHUB_REF#refs/tags/}" "dotslash-macos-x86_64.tar.gz"
+          gh release upload "${GITHUB_REF#refs/tags/}" dotslash-macos.tar.gz
+          gh release upload "${GITHUB_REF#refs/tags/}" dotslash-macos-arm64.tar.gz
+          gh release upload "${GITHUB_REF#refs/tags/}" dotslash-macos-x86_64.tar.gz
       # TODO(#68): Deprecated; will be removed in a future release!
       # Package universal binary
       - run: tar -czvf "dotslash-macos.${GITHUB_REF#refs/tags/}.tar.gz" dotslash
@@ -79,12 +79,12 @@ jobs:
       - run: cargo test
       - run: cargo clippy
       - run: cargo build --release
-      - run: tar -czvf "dotslash-ubuntu-22.04.x86_64.tar.gz" -C target/release dotslash
+      - run: tar -cvf dotslash-ubuntu-22.04.x86_64.tar.gz -I 'gzip -9' -C target/release dotslash
       - name: upload release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
-        run: gh release upload "${GITHUB_REF#refs/tags/}" "dotslash-ubuntu-22.04.x86_64.tar.gz"
+        run: gh release upload "${GITHUB_REF#refs/tags/}" dotslash-ubuntu-22.04.x86_64.tar.gz
       # TODO(#68): Deprecated; will be removed in a future release!
       - run: tar -czvf "dotslash-ubuntu-22.04.x86_64.${GITHUB_REF#refs/tags/}.tar.gz" -C target/release dotslash
       - name: upload versioned release
@@ -109,7 +109,7 @@ jobs:
       - run: cargo build --target aarch64-unknown-linux-gnu --release
         env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
-      - run: tar -czvf "dotslash-ubuntu-22.04.aarch64.tar.gz" -C target/aarch64-unknown-linux-gnu/release dotslash
+      - run: tar -cvf dotslash-ubuntu-22.04.aarch64.tar.gz -I 'gzip -9' -C target/aarch64-unknown-linux-gnu/release dotslash
       - name: upload release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -139,7 +139,7 @@ jobs:
       - run: cargo test
       - run: cargo clippy
       - run: cargo build --target x86_64-unknown-linux-musl --release
-      - run: tar -czvf "dotslash-linux-musl.x86_64.tar.gz" -C target/x86_64-unknown-linux-musl/release dotslash
+      - run: tar -cvf dotslash-linux-musl.x86_64.tar.gz -I 'gzip -9' -C target/x86_64-unknown-linux-musl/release dotslash
       - name: upload release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -167,7 +167,7 @@ jobs:
           crate: cross
           version: latest
       - run: cross build --target aarch64-unknown-linux-musl --release
-      - run: tar -czvf "dotslash-linux-musl.aarch64.tar.gz" -C target/aarch64-unknown-linux-musl/release dotslash
+      - run: tar -cvf dotslash-linux-musl.aarch64.tar.gz -I 'gzip -9' -C target/aarch64-unknown-linux-musl/release dotslash
       - name: upload release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -191,7 +191,7 @@ jobs:
       - run: cargo test
       - run: cargo clippy
       - run: cargo build --release
-      - run: tar czvf dotslash-windows.tar.gz -C target/release dotslash.exe
+      - run: tar czvf dotslash-windows.tar.gz --options gzip:compression-level=9 -C target/release dotslash.exe
         shell: cmd
       - name: upload release
         env:

--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -23,14 +23,26 @@ We provide prebuilt binaries for macOS, [Ubuntu] Linux, and Windows on GitHub:
 
 <https://github.com/facebook/dotslash/releases/latest>
 
-For the reasons explained above, the macOS release is a Universal Binary.
-
 Once you have downloaded DotSlash, you must ensure that `dotslash` (or
 `dotslash.exe` on Windows) is on your `PATH`. You can test that it is setup
 correctly on Mac or Linux by running:
 
 ```shell
 /usr/bin/env dotslash --help
+```
+
+### Linux
+
+```shell
+curl -LSfs "https://github.com/facebook/dotslash/releases/latest/download/dotslash-ubuntu-22.04.$(uname -m).tar.gz" | tar fxz - -C YOUR_BIN_PATH
+```
+
+### macOS
+
+For the reasons explained above, the macOS release is a Universal Binary.
+
+```shell
+curl -LSfs https://github.com/facebook/dotslash/releases/latest/download/dotslash-macos.tar.gz | tar fxz - -C YOUR_BIN_PATH
 ```
 
 :::warning
@@ -44,6 +56,12 @@ xattr -r -d com.apple.quarantine ~/Downloads/dotslash-macos.*.tar.gz
 ```
 
 :::
+
+### Windows
+
+```cmd
+cmd /c 'curl.exe -LSfs https://github.com/facebook/dotslash/releases/latest/download/dotslash-windows.tar.gz | tar fxz - -C YOUR_BIN_PATH'
+```
 
 ## GitHub Actions
 


### PR DESCRIPTION
This re-implements #17 now that we have fixed the underlying issues that caused it to get reverted in the first place.

I've done the documentation a bit differently to try and make it a bit cleaner.  I also did not update the versioned artifacts that are due for removal in #68.