### PR TITLE
Create an S3 provider for fetching artifacts

### DIFF
--- a/src/default_provider_factory.rs
+++ b/src/default_provider_factory.rs
@@ -12,6 +12,7 @@ use crate::github_release_provider::GitHubReleaseProvider;
 use crate::http_provider::HttpProvider;
 use crate::provider::Provider;
 use crate::provider::ProviderFactory;
+use crate::s3_provider::S3Provider;
 
 pub struct DefaultProviderFactory;
 
@@ -20,6 +21,7 @@ impl ProviderFactory for DefaultProviderFactory {
         match provider_type {
             "http" => Ok(Box::new(HttpProvider {})),
             "github-release" => Ok(Box::new(GitHubReleaseProvider {})),
+            "s3" => Ok(Box::new(S3Provider {})),
             _ => Err(anyhow::format_err!(
                 "unknown provider type: `{provider_type}`",
             )),

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ mod locate;
 mod platform;
 mod print_entry_for_url;
 mod provider;
+mod s3_provider;
 mod subcommand;
 mod util;
 

--- a/src/s3_provider.rs
+++ b/src/s3_provider.rs
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is dual-licensed under either the MIT license found in the
+ * LICENSE-MIT file in the root directory of this source tree or the Apache
+ * License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+ * of this source tree. You may select, at your option, one of the
+ * above-listed licenses.
+ */
+
+use std::path::Path;
+
+use anyhow::Context as _;
+use serde::Deserialize;
+use serde_jsonrc::value::Value;
+
+use crate::config::ArtifactEntry;
+use crate::provider::Provider;
+use crate::util::{CommandDisplay, CommandStderrDisplay, FileLock};
+
+pub struct S3Provider {}
+
+#[derive(Deserialize, Debug)]
+struct S3ProviderConfig {
+    bucket: String,
+    key: String,
+    region: Option<String>,
+}
+
+impl Provider for S3Provider {
+    fn fetch_artifact(
+        &self,
+        provider_config: &Value,
+        destination: &Path,
+        _fetch_lock: &FileLock,
+        _: &ArtifactEntry,
+    ) -> anyhow::Result<()> {
+        let S3ProviderConfig {
+            bucket,
+            key,
+            region,
+        } = <_>::deserialize(provider_config)?;
+        let mut command = std::process::Command::new("aws");
+        command.args(&["s3", "cp"]);
+        if let Some(region) = region {
+            command.args(&["--region", &region]);
+        }
+        command.arg(format!("s3://{bucket}/{key}"));
+        command.arg(destination);
+        let output = command
+            .output()
+            .with_context(|| format!("{}", CommandDisplay::new(&command)))
+            .context("failed to run the AWS CLI")?;
+
+        if !output.status.success() {
+            return Err(anyhow::format_err!(
+                "{}",
+                CommandStderrDisplay::new(&output)
+            ))
+            .with_context(|| format!("{}", CommandDisplay::new(&command)))
+            .context("the AWS CLI failed");
+        }
+        Ok(())
+    }
+}

--- a/website/docs/dotslash-file.md
+++ b/website/docs/dotslash-file.md
@@ -344,6 +344,36 @@ be:
 
 And the `--repo` value passed to `gh` would also be changed, accordingly.
 
+### S3 Provider
+
+The S3 provider allows fetching artifacts from S3 (or any other compatible
+object store) using the [`aws` CLI](https://aws.amazon.com/cli/). The advantage
+of the S3 provider is that it allows you to retrieve artifacts from S3 buckets
+that are not accessible via HTTP (e.g. private).
+
+```json
+{
+  "type": "s3",
+  "repo": "example",
+  "key": "key",
+  "region": "us-west-2"
+}
+```
+
+gets translated into the following command in order to do the fetch:
+
+```shell
+aws s3 cp --region us-weset-2 s3://example/key TEMPFILE_IN_DOTSLASH_CACHE
+```
+
+Note: the "region" key is optional. By default, your default AWS region will be
+used.
+
+You will need to have the `aws` CLI configured to pick up the required
+credentials. Either via its built-in credentials mechanism, or wrapping the
+`dotslash` invocation tools such as
+[`aws-vault`](https://github.com/99designs/aws-vault).
+
 ## Artifact Format
 
 Although it may appear that `format` can be an arbitrary file extension,


### PR DESCRIPTION
We've been rolling out usage of dotslash at Stile, thanks for building such a useful tool! One thing that has been useful for us is to be able to download binaries from S3 when you don't necessarily have HTTP access (e.g. private bucket, HTTP access locked down to particular IPs, etc). I've been trialing the S3 provider for a little bit so am hoping to upstream it. There seems to be some wider interest in it based on https://github.com/facebook/dotslash/issues/30.

I've followed the same style as the GitHub and HTTP providers of using a CLI. So, this requires that the `aws` CLI is installed.

Closes: #30