### PR TITLE
Update installation docs

### DIFF
--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -110,7 +110,12 @@ jobs:
       - run: ./some_dotslash_file
 ```
 
-## cargo install
+## Package managers
+
+DotSlash is available through several language- and platform-specific package
+managers.
+
+### Cargo
 
 If you are familiar with the Rust toolchain, you can also build and install
 DotSlash using `cargo`:
@@ -125,7 +130,7 @@ update any environment variables to get DotSlash to work.
 Though note that `cargo install` does not create a universal binary, so you may
 be better off [building from source](#build-from-source).
 
-## Install from npm
+### npm
 
 To use DotSlash in Node.js projects, you can install it as a dependency:
 
@@ -152,6 +157,16 @@ const dotslash = require('fb-dotslash');
 const {spawnSync} = require('child_process');
 spawnSync(dotslash, ['./some_dotslash_file'], {stdio: 'inherit']);
 ```
+
+### Scoop
+
+On Windows, DotSlash can be installed via [Scoop](https://scoop.sh):
+
+```shell
+scoop install dotslash
+```
+
+Scoop will place `dotslash.exe` on your `PATH` automatically.
 
 ## Build from source
 


### PR DESCRIPTION
This documents support for the Scoop package manager which I [added](https://github.com/ScoopInstaller/Main/pull/7976) last night. Also, I took the liberty of nesting the package manager sections under a single grouping.

### Before

<img width="225" height="561" alt="image" src="https://github.com/user-attachments/assets/3ecd8f82-a6a4-44f9-9127-6d447207b5c3" />

### After

<img width="227" height="671" alt="image" src="https://github.com/user-attachments/assets/9ec4e274-b100-4759-9a4a-c1ca545a7e08" />