### PR TITLE
Improve default permissions for raw artifacts

### DIFF
--- a/src/util/chmodx.rs
+++ b/src/util/chmodx.rs
@@ -16,7 +16,7 @@ use std::path::Path;
 
 use crate::util::fs_ctx;
 
-const DEFAULT_FILE_PERMISSIONS: u32 = 0o500;
+const DEFAULT_FILE_PERMISSIONS: u32 = 0o555;
 
 pub fn chmodx<P: AsRef<Path>>(path: P) -> io::Result<()> {
     fn inner(path: &Path) -> io::Result<()> {

--- a/tests/dotslash_tests.rs
+++ b/tests/dotslash_tests.rs
@@ -14,6 +14,8 @@ mod common;
 
 use std::ffi::OsString;
 use std::fs;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt as _;
 use std::str;
 
 use tempfile::NamedTempFile;
@@ -903,6 +905,34 @@ fn fetch_simple() -> anyhow::Result<()> {
 
     let metadata = fs::metadata(artifact)?;
     assert!(metadata.is_file());
+
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn fetch_plain_sets_default_executable_permissions() -> anyhow::Result<()> {
+    let mut test_env = DotslashTestEnv::try_new()?;
+    test_env.path_redaction(
+        "[ARTIFACT_EXE]",
+        "[DOTSLASH_CACHE_DIR]/[PACK_PLAIN_HTTP_ARCHIVE_CACHE_DIR]/subdir/[PRINT_ARGV_EXECUTABLE]",
+    );
+
+    let assert = test_env
+        .dotslash_command()
+        .arg("--")
+        .arg("fetch")
+        .arg("tests/fixtures/http__plain__print_argv")
+        .assert()
+        .code(0)
+        .stderr_eq("")
+        .stdout_eq("[ARTIFACT_EXE]\n");
+
+    let artifact = str::from_utf8(&assert.get_output().stdout)?.trim_end();
+
+    let metadata = fs::metadata(artifact)?;
+    assert!(metadata.is_file());
+    assert_eq!(metadata.permissions().mode() & 0o777, 0o555);
 
     Ok(())
 }

--- a/website/docs/dotslash-file.md
+++ b/website/docs/dotslash-file.md
@@ -475,6 +475,9 @@ At Meta, we have found compression to be a win, but if for some reason you
 prefer to fetch your executable as an uncompressed single file, you can omit the
 `"format"` field, but `"path"` is still required.
 
+For single-file artifacts on Unix, if the fetched file has no executable bits,
+DotSlash makes the cached file executable with mode `0555` (`r-xr-xr-x`).
+
 ## Arg0
 
 There is an optional `arg0` field on an artifact entry. It defaults to


### PR DESCRIPTION
Fixes #107.

This changes the fallback mode for single-file artifacts on Unix from owner-executable only to all-users executable.

Validation on my Windows machine:

```
❯ $env.RUSTFLAGS = "-Awarnings"
❯ cargo fmt --check --quiet
❯ cargo test --quiet

running 48 tests
................................................
test result: ok. 48 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s


running 43 tests
...........................................
test result: ok. 43 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.09s
❯ devcontainer exec --workspace-folder . --remote-env $"RUSTFLAGS=($env.RUSTFLAGS)" cargo test --quiet

running 49 tests
.................................................
test result: ok. 49 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s


running 44 tests
............................................
test result: ok. 44 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.07s
❯ devcontainer exec --workspace-folder . cargo clippy --quiet -- $env.RUSTFLAGS
❯
```